### PR TITLE
Construct dato server with datomic uri

### DIFF
--- a/src/dato/lib/incoming.clj
+++ b/src/dato/lib/incoming.clj
@@ -134,9 +134,9 @@
 (def black-listed-attr-ns?
   #{"db"})
 
-(defn outgoing-tx-report [db tx-report]
+(defn outgoing-tx-report [tx-report]
   (def outgoing-tx tx-report)
-  (let [tx-guid             (when-let [datom (first (filter #(= (d/ident db (:a %)) :tx/guid) (:tx-data outgoing-tx)))]
+  (let [tx-guid             (when-let [datom (first (filter #(= (d/ident (:db-after tx-report) (:a %)) :tx/guid) (:tx-data outgoing-tx)))]
                               (:v datom))
         guid-map            (outgoing-guid-map tx-report)
         datoms              (for [{:keys [e a v tx added]} (:tx-data tx-report)]

--- a/src/dato/lib/server.clj
+++ b/src/dato/lib/server.clj
@@ -33,8 +33,11 @@
                                                         (transit/write-handler (constantly "datascript/Datom")
                                                                                transit-rep)}))
 
+(defn dconn [dato-server]
+  (d/connect (:datomic-uri dato-server)))
+
 (defn ddb [dato-server]
-  (d/db ((:conn-fn dato-server))))
+  (d/db (dconn dato-server)))
 
 (defn user-db
   "Currently a placeholder for a filtered-db with only datoms the
@@ -97,7 +100,6 @@
 (defn broadcast-tx! [dato-server sessions tx-report]
   (def last-tx-report tx-report)
   (def l-dato-server dato-server)
-  (def l-conn-fn (:conn-fn dato-server))
   (let [data        (incoming/outgoing-tx-report tx-report)
         _           (def last-tx-data data)
         payload     (ss-msg :server/database-transacted data)
@@ -288,7 +290,7 @@
         dato-server  (session-server full-session)
         _            (def l-session session)
         _            (def l-dato-server dato-server)
-        conn         ((:conn-fn dato-server))
+        conn         (dconn dato-server)
         datoms       (:tx-data incoming)
         tx-guid      (:tx/guid incoming)
         meta         (assoc (:tx-meta incoming) :tx/guid tx-guid)
@@ -318,7 +320,7 @@
 (defn new-session-id []
   (str (UUID/randomUUID)))
 
-(defrecord DatoServer [routing-table conn-fn]  )
+(defrecord DatoServer [routing-table datomic-uri]  )
 
 (defn ?assign-id [handler dato-server]
   (fn [request]
@@ -343,5 +345,5 @@
             (imw/wrap-session))
         {:path "/ws"
          :host "0.0.0.0"}))
-    (setup-tx-report-ch ((:conn-fn @dato-server)))
+    (setup-tx-report-ch (dconn @dato-server))
     (def stop-tx-broadcast-ch (start-tx-broadcast! dato-server tx-report-mult))))

--- a/src/dato/lib/server.clj
+++ b/src/dato/lib/server.clj
@@ -98,7 +98,7 @@
   (def last-tx-report tx-report)
   (def l-dato-server dato-server)
   (def l-conn-fn (:conn-fn dato-server))
-  (let [data        (incoming/outgoing-tx-report (d/db ((:conn-fn @dato-server))) tx-report)
+  (let [data        (incoming/outgoing-tx-report tx-report)
         _           (def last-tx-data data)
         payload     (ss-msg :server/database-transacted data)
         enc-payload (cdc/encode payload :transit)]

--- a/src/dato/server.clj
+++ b/src/dato/server.clj
@@ -70,7 +70,7 @@
 
 (def dato-server
   (dato/map->DatoServer {:routing-table #'dato-routes
-                         :conn-fn       datod/conn}))
+                         :datomic-uri   datod/default-uri}))
 
 (defn run [& [port]]
   (dato/start! handler {:server (var dato-server)


### PR DESCRIPTION
Also pulls db out of tx-report instead of passing it in. Not exactly related, but was one of the places that was using the conn-fn.
